### PR TITLE
feat: Transform @Emit decorators

### DIFF
--- a/example/src/components/Test.vue
+++ b/example/src/components/Test.vue
@@ -50,5 +50,10 @@ export default class Test extends Vue {
   log(count: number) {
     console.log(count)
   }
+
+  @Emit()
+  doSomething(): void {
+      this.log(5);
+  }
 }
 </script>

--- a/example/src/components/Test.vue
+++ b/example/src/components/Test.vue
@@ -51,7 +51,7 @@ export default class Test extends Vue {
     console.log(count)
   }
 
-  @Emit()
+  @Emit('something)
   doSomething(): void {
       this.log(5);
   }

--- a/example/src/components/Test.vue
+++ b/example/src/components/Test.vue
@@ -51,7 +51,7 @@ export default class Test extends Vue {
     console.log(count)
   }
 
-  @Emit('something)
+  @Emit('something')
   doSomething(): void {
       this.log(5);
   }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -832,3 +832,31 @@ export default Vue.extend({
 
   validate(t, source, truth)
 })
+
+test('emits should emit the method parameters of the decorated method', t => {
+  const source = `
+@Component
+export default class Component extends Vue {
+  
+  @Emit('something')
+  doSomething(someNumber: number, someString: string): void {
+      console.log('Hello, world!')
+  }
+}
+  `
+
+  const truth = `
+import Vue from 'vue';
+export default Vue.extend({
+  name: 'Component',
+  methods: {
+    doSomething(someNumber: number, someString: string): void {
+      console.log('Hello, world!')
+      this.$emit('something', someNumber, someString);
+    },
+  },
+});
+  `
+
+  validate(t, source, truth)
+})

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -18,8 +18,8 @@ const project = new Project({
 })
 
 function validate<T>(
-  context: ExecutionContext<T>, 
-  source: string, 
+  context: ExecutionContext<T>,
+  source: string,
   truth: string,
   mode: 'ts' | 'vue' = 'ts',
 ) {
@@ -488,7 +488,7 @@ export default Vue.extend({
   },
 });
   `
-  
+
   validate(t, source, truth)
 })
 
@@ -530,7 +530,7 @@ export default Vue.extend({
   },
 });
   `
-  
+
   validate(t, source, truth)
 })
 
@@ -562,7 +562,7 @@ export default Vue.extend({
   },
 });
   `
-  
+
   validate(t, source, truth)
 })
 
@@ -608,7 +608,7 @@ export default Vue.extend({
   },
 });
   `
-  
+
   validate(t, source, truth)
 })
 
@@ -664,7 +664,7 @@ export default Vue.extend({
   },
 });
   `
-  
+
   validate(t, source, truth)
 })
 
@@ -716,7 +716,7 @@ export default Vue.extend({
   },
 });
   `
-  
+
   validate(t, source, truth)
 })
 
@@ -770,7 +770,7 @@ export default Vue.extend({
   },
 });
   `
-  
+
   validate(t, source, truth)
 })
 
@@ -801,6 +801,34 @@ export default Vue.extend({
   },
 });
   `
+
+  validate(t, source, truth)
+})
+
+test('converts emit decorators correctly', t => {
+  const source = `
+@Component
+export default class Component extends Vue {
   
+  @Emit('something')
+  doSomething(): void {
+      console.log('Hello, world!')
+  }
+}
+  `
+
+  const truth = `
+import Vue from 'vue';
+export default Vue.extend({
+  name: 'Component',
+  methods: {
+    doSomething(): void {
+      console.log('Hello, world!')
+      this.$emit('something');
+    },
+  },
+});
+  `
+
   validate(t, source, truth)
 })

--- a/src/operations/vue_class.ts
+++ b/src/operations/vue_class.ts
@@ -215,27 +215,24 @@ function unpackClass(declaration: ClassDeclaration) {
   }
 
   function handleEmitDecorator(decorator: Decorator, method: MethodDeclaration) {
-    const decoratorArguments = decorator.getArguments()
-
-    if (decoratorArguments.length === 0) {
-      throw new Error('@Emit does not have at least its first argument.')
-    }
-
-    const emitNameLiteral = decoratorArguments[0]
+    const [emitNameLiteral] = decorator.getArguments();
 
     if (!(emitNameLiteral instanceof StringLiteral)) {
-      throw new Error('The first argument to @Emit is not a string literal.')
+      throw new Error('The first argument to @Emit must be a string literal.');
     }
 
     const emitName = emitNameLiteral.getLiteralValue();
-    let emitStatement = `this.$emit(\'${emitName}\');`;
+    const parameters = method.getParameters().map(param => param.getName());
+    const parameterList = parameters.join(', ');
+    const emitStatement = `this.$emit('${emitName}'${parameterList ? `, ${parameterList}` : ''});`;
 
-    if (method.getBodyText() !== "") {
-      emitStatement = '\n' + emitStatement;
-    }
+    const updatedBody = method.getBodyText()
+        ? `${method.getBodyText()}\n${emitStatement}`
+        : emitStatement;
 
-    method.setBodyText(method.getBodyText()  + emitStatement)
+    method.setBodyText(updatedBody);
   }
+
 
   for (const method of declaration.getInstanceMethods()) {
     for (const decorator of method.getDecorators()) {


### PR DESCRIPTION
There are codebases heavily relying on the @Emit decorator. If the decorator is found, append to the end of the method body calls to the built-in `$emit` method; multiple `@Emit` decorators are also possible.
- added transformation support for the `@Emit` decorators
- extended the `Text.vue` file with an example