### PR TITLE
new: Handle emit decorators.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Here's the plan for the project:
 - [x] `@Component`
 - [x] `@Prop`
 - [x] `@Watch`
+- [x] `@Emit` (contributed by [@LeVoMihalcea](https://github.com/LeVoMihalcea))
 - [ ] `@PropSync`
 - [x] JSDocs for all of the above
 

--- a/example/src/components/Test.vue
+++ b/example/src/components/Test.vue
@@ -50,5 +50,10 @@ export default class Test extends Vue {
   log(count: number) {
     console.log(count)
   }
+
+  @Emit()
+  doSomething(): void {
+      this.log(5);
+  }
 }
 </script>

--- a/example/src/components/Test.vue
+++ b/example/src/components/Test.vue
@@ -52,8 +52,8 @@ export default class Test extends Vue {
   }
 
   @Emit('something')
-  doSomething(): void {
-      this.log(5);
+  doSomething() {
+    this.log(5)
   }
 }
 </script>

--- a/example/src/components/Test.vue
+++ b/example/src/components/Test.vue
@@ -51,7 +51,7 @@ export default class Test extends Vue {
     console.log(count)
   }
 
-  @Emit()
+  @Emit('something)
   doSomething(): void {
       this.log(5);
   }

--- a/example/src/components/Test.vue
+++ b/example/src/components/Test.vue
@@ -51,7 +51,7 @@ export default class Test extends Vue {
     console.log(count)
   }
 
-  @Emit('something)
+  @Emit('something')
   doSomething(): void {
       this.log(5);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "vue-declassify",
       "version": "1.0.6",
       "license": "MIT",
       "dependencies": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -832,3 +832,31 @@ export default Vue.extend({
 
   validate(t, source, truth)
 })
+
+test('emits should emit the method parameters of the decorated method', t => {
+  const source = `
+@Component
+export default class Component extends Vue {
+  
+  @Emit('something')
+  doSomething(someNumber: number, someString: string): void {
+      console.log('Hello, world!')
+  }
+}
+  `
+
+  const truth = `
+import Vue from 'vue';
+export default Vue.extend({
+  name: 'Component',
+  methods: {
+    doSomething(someNumber: number, someString: string): void {
+      console.log('Hello, world!')
+      this.$emit('something', someNumber, someString);
+    },
+  },
+});
+  `
+
+  validate(t, source, truth)
+})

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -18,8 +18,8 @@ const project = new Project({
 })
 
 function validate<T>(
-  context: ExecutionContext<T>, 
-  source: string, 
+  context: ExecutionContext<T>,
+  source: string,
   truth: string,
   mode: 'ts' | 'vue' = 'ts',
 ) {
@@ -488,7 +488,7 @@ export default Vue.extend({
   },
 });
   `
-  
+
   validate(t, source, truth)
 })
 
@@ -530,7 +530,7 @@ export default Vue.extend({
   },
 });
   `
-  
+
   validate(t, source, truth)
 })
 
@@ -562,7 +562,7 @@ export default Vue.extend({
   },
 });
   `
-  
+
   validate(t, source, truth)
 })
 
@@ -608,7 +608,7 @@ export default Vue.extend({
   },
 });
   `
-  
+
   validate(t, source, truth)
 })
 
@@ -664,7 +664,7 @@ export default Vue.extend({
   },
 });
   `
-  
+
   validate(t, source, truth)
 })
 
@@ -716,7 +716,7 @@ export default Vue.extend({
   },
 });
   `
-  
+
   validate(t, source, truth)
 })
 
@@ -770,7 +770,7 @@ export default Vue.extend({
   },
 });
   `
-  
+
   validate(t, source, truth)
 })
 
@@ -801,6 +801,34 @@ export default Vue.extend({
   },
 });
   `
+
+  validate(t, source, truth)
+})
+
+test('converts emit decorators correctly', t => {
+  const source = `
+@Component
+export default class Component extends Vue {
   
+  @Emit('something')
+  doSomething(): void {
+      console.log('Hello, world!')
+  }
+}
+  `
+
+  const truth = `
+import Vue from 'vue';
+export default Vue.extend({
+  name: 'Component',
+  methods: {
+    doSomething(): void {
+      console.log('Hello, world!')
+      this.$emit('something');
+    },
+  },
+});
+  `
+
   validate(t, source, truth)
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -805,14 +805,14 @@ export default Vue.extend({
   validate(t, source, truth)
 })
 
-test('converts emit decorators correctly', t => {
+test('converts unnamed emits correctly', t => {
   const source = `
 @Component
 export default class Component extends Vue {
   
-  @Emit('something')
-  doSomething(): void {
-      console.log('Hello, world!')
+  @Emit()
+  onGreet() {
+    console.log('Hello, world!')
   }
 }
   `
@@ -822,9 +822,9 @@ import Vue from 'vue';
 export default Vue.extend({
   name: 'Component',
   methods: {
-    doSomething(): void {
+    onGreet() {
       console.log('Hello, world!')
-      this.$emit('something');
+      this.$emit('onGreet')
     },
   },
 });
@@ -833,14 +833,14 @@ export default Vue.extend({
   validate(t, source, truth)
 })
 
-test('emits should emit the method parameters of the decorated method', t => {
+test('converts named emits correctly', t => {
   const source = `
 @Component
 export default class Component extends Vue {
   
-  @Emit('something')
-  doSomething(someNumber: number, someString: string): void {
-      console.log('Hello, world!')
+  @Emit('greet')
+  onGreet() {
+    console.log('Hello, world!')
   }
 }
   `
@@ -850,9 +850,67 @@ import Vue from 'vue';
 export default Vue.extend({
   name: 'Component',
   methods: {
-    doSomething(someNumber: number, someString: string): void {
+    onGreet() {
       console.log('Hello, world!')
-      this.$emit('something', someNumber, someString);
+      this.$emit('greet')
+    },
+  },
+});
+  `
+
+  validate(t, source, truth)
+})
+
+test('converts emits on functions with arguments correctly', t => {
+  const source = `
+@Component
+export default class Component extends Vue {
+  
+  @Emit('greet')
+  onGreet(name: string) {
+    console.log(\`Hello, \${name}!\`)
+  }
+}
+  `
+
+  const truth = `
+import Vue from 'vue';
+export default Vue.extend({
+  name: 'Component',
+  methods: {
+    onGreet(name: string) {
+      console.log(\`Hello, \${name}!\`)
+      this.$emit('greet', name)
+    },
+  },
+});
+  `
+
+  validate(t, source, truth)
+})
+
+test('converts multiple emits correctly', t => {
+  const source = `
+@Component
+export default class Component extends Vue {
+  
+  @Emit()
+  @Emit('greet')
+  onGreet(name: string) {
+    console.log(\`Hello, \${name}!\`)
+  }
+}
+  `
+
+  const truth = `
+import Vue from 'vue';
+export default Vue.extend({
+  name: 'Component',
+  methods: {
+    onGreet(name: string) {
+      console.log(\`Hello, \${name}!\`)
+      this.$emit('onGreet', name)
+      this.$emit('greet', name)
     },
   },
 });

--- a/src/operations/vue_class.ts
+++ b/src/operations/vue_class.ts
@@ -215,27 +215,24 @@ function unpackClass(declaration: ClassDeclaration) {
   }
 
   function handleEmitDecorator(decorator: Decorator, method: MethodDeclaration) {
-    const decoratorArguments = decorator.getArguments()
-
-    if (decoratorArguments.length === 0) {
-      throw new Error('@Emit does not have at least its first argument.')
-    }
-
-    const emitNameLiteral = decoratorArguments[0]
+    const [emitNameLiteral] = decorator.getArguments();
 
     if (!(emitNameLiteral instanceof StringLiteral)) {
-      throw new Error('The first argument to @Emit is not a string literal.')
+      throw new Error('The first argument to @Emit must be a string literal.');
     }
 
     const emitName = emitNameLiteral.getLiteralValue();
-    let emitStatement = `this.$emit(\'${emitName}\');`;
+    const parameters = method.getParameters().map(param => param.getName());
+    const parameterList = parameters.join(', ');
+    const emitStatement = `this.$emit('${emitName}'${parameterList ? `, ${parameterList}` : ''});`;
 
-    if (method.getBodyText() !== "") {
-      emitStatement = '\n' + emitStatement;
-    }
+    const updatedBody = method.getBodyText()
+        ? `${method.getBodyText()}\n${emitStatement}`
+        : emitStatement;
 
-    method.setBodyText(method.getBodyText()  + emitStatement)
+    method.setBodyText(updatedBody);
   }
+
 
   for (const method of declaration.getInstanceMethods()) {
     for (const decorator of method.getDecorators()) {


### PR DESCRIPTION
Contributed by @LeVoMihalcea via #6.

I have adjusted the code style to fit the rest of the program and added some tests.

It turns out `@Emit` can be used with no parameters, so I implemented that fallback as well.